### PR TITLE
Performance

### DIFF
--- a/blob/lib/azure/storage/blob/blob.rb
+++ b/blob/lib/azure/storage/blob/blob.rb
@@ -99,7 +99,7 @@ module Azure::Storage
 
           # if after adjusting end_range for blob_size, may be appropriate to single_get
           if chunk_size <= single_get_threshold
-            return get_blob(container, blob, options.merge({single_get: true, start_range: start, end_range: fin}))
+            return get_blob(container, blob, options.merge({single_get: true}))
           end
 
           thread_count = 15

--- a/blob/lib/azure/storage/blob/block.rb
+++ b/blob/lib/azure/storage/blob/block.rb
@@ -468,10 +468,24 @@ module Azure::Storage
         # Get the number of blocks
         block_count = (Float(size) / Float(block_size)).ceil
         block_list = []
-        for block_id in 0...block_count
-          id = block_id.to_s.rjust(6, "0")
-          put_blob_block(container, blob, id, content.read(block_size), timeout: options[:timeout], lease_id: options[:lease_id])
-          block_list.push([id])
+
+        # Split the block list into groups of threads and upload in parallel
+        max_thread_count = 15
+        (0..block_count - 1).to_a.each_slice(max_thread_count) do |block_slice|
+          threads = []
+          thread_count = block_slice.length
+          block_slice_data = content.read(block_size * thread_count)
+          block_slice.each_with_index do |block_id, index_in_block_slice|
+            thread = Thread.new do
+              id = block_id.to_s.rjust(6, "0")
+              put_blob_block(container, blob, id, block_slice_data.slice(index_in_block_slice * block_size, block_size), timeout: options[:timeout], lease_id: options[:lease_id])
+              [id]
+            end
+            thread.abort_on_exception = true
+            threads << thread
+          end
+
+          block_list.concat threads.map(&:value).sort
         end
 
         # Commit the blocks put
@@ -521,7 +535,7 @@ module Azure::Storage
         if size > BlobConstants::MAX_BLOCK_BLOB_SIZE
           raise ArgumentError, "Block blob size should be less than #{BlobConstants::MAX_BLOCK_BLOB_SIZE} bytes in size"
         elsif (size / BlobConstants::MAX_BLOCK_COUNT) < BlobConstants::DEFAULT_WRITE_BLOCK_SIZE_IN_BYTES
-          BlobConstants::DEFAULT_WRITE_BLOCK_SIZE_IN_BYTES
+          ENV.fetch("AZURE_DEFAULT_WRITE_BLOCK_SIZE_IN_BYTES", BlobConstants::DEFAULT_WRITE_BLOCK_SIZE_IN_BYTES).to_i
         else
           BlobConstants::MAX_BLOCK_SIZE
         end

--- a/blob/lib/azure/storage/blob/default.rb
+++ b/blob/lib/azure/storage/blob/default.rb
@@ -86,7 +86,7 @@ module Azure::Storage::Blob
     DEFAULT_SINGLE_BLOB_PUT_THRESHOLD_IN_BYTES = 128 * 1024 * 1024
 
     # The default write block size, in bytes, used by blob streams.
-    DEFAULT_WRITE_BLOCK_SIZE_IN_BYTES = 4 * 1024 * 1024
+    DEFAULT_WRITE_BLOCK_SIZE_IN_BYTES = 5 * 1024 * 1024
 
     # The maximum size of a single block.
     MAX_BLOCK_SIZE = 100 * 1024 * 1024

--- a/blob/lib/azure/storage/blob/version.rb
+++ b/blob/lib/azure/storage/blob/version.rb
@@ -31,7 +31,7 @@ module Azure
         # Fields represent the parts defined in http://semver.org/
         MAJOR = 2 unless defined? MAJOR
         MINOR = 0 unless defined? MINOR
-        UPDATE = 1 unless defined? UPDATE
+        UPDATE = "1-buckelij" unless defined? UPDATE
 
         class << self
           # @return [String]

--- a/common/lib/azure/storage/common/core/http_client.rb
+++ b/common/lib/azure/storage/common/core/http_client.rb
@@ -26,6 +26,7 @@
 
 module Azure::Storage::Common::Core
   module HttpClient
+    POOL_SIZE = 20
     # Returns the http agent based on uri
     # @param uri  [URI|String] the base uri (scheme, host, port) of the http endpoint
     # @return [Net::HTTP] http agent for a given uri
@@ -72,7 +73,7 @@ module Azure::Storage::Common::Core
                         end || nil
         Faraday.new(uri, ssl: ssl_options, proxy: proxy_options) do |conn|
           conn.use FaradayMiddleware::FollowRedirects
-          conn.adapter :net_http_persistent, pool_size: 5 do |http|
+          conn.adapter :net_http_persistent, pool_size: POOL_SIZE do |http|
             # yields Net::HTTP::Persistent
             http.idle_timeout = 100
           end

--- a/common/lib/azure/storage/common/version.rb
+++ b/common/lib/azure/storage/common/version.rb
@@ -31,7 +31,7 @@ module Azure
         # Fields represent the parts defined in http://semver.org/
         MAJOR = 2 unless defined? MAJOR
         MINOR = 0 unless defined? MINOR
-        UPDATE = 2 unless defined? UPDATE
+        UPDATE = "2-buckelij" unless defined? UPDATE
 
         class << self
           # @return [String]


### PR DESCRIPTION
stub PR for the 1-buckelij patched version with parallel performance improvements. 

packaged as azure-storage-blob (2.0.1.pre.buckelij) with 

```
/workspaces/azure-storage-ruby/blob (performance2-nokogiri ✗) $ gem build azure-storage-blob.gemspec
```