### PR TITLE
parallel upload, ranged get

### DIFF
--- a/blob/lib/azure/storage/blob/blob.rb
+++ b/blob/lib/azure/storage/blob/blob.rb
@@ -23,6 +23,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 #--------------------------------------------------------------------------
+require 'thread'
 
 module Azure::Storage
   module Blob
@@ -82,11 +83,17 @@ module Azure::Storage
     #                                   - The lease ID specified in the request matches that of the blob.
     #                                  If this header is specified and both of these conditions are not met, the request will fail
     #                                  and the Get Blob operation will fail with status code 412 (Precondition Failed).
+    # * +:parallel_threshold+        - Integer. Complete the request concurrently if the specified range >= this threshold.
+    #                                  Takes precedence over the storage_blob_parallel_threshold client option.
     #
     # See http://msdn.microsoft.com/en-us/library/azure/dd179440.aspx
     #
     # Returns a blob and the blob body
     def get_blob(container, blob, options = {})
+      if options[:end_range].to_i - options[:start_range].to_i >= parallel_threshold(options)
+        return get_blob_parallel(container, blob, options)
+      end
+
       query = {}
       StorageService.with_query query, "snapshot", options[:snapshot]
       StorageService.with_query query, "timeout", options[:timeout] if options[:timeout]
@@ -928,5 +935,50 @@ module Azure::Storage
       call(:delete, uri, nil, headers, options)
       nil
     end
+
+    # Private: executes get_blob with threads
+    #
+    # Returns a blob and the blob body
+    private
+      def get_blob_parallel(container, blob, options)
+        blob_size = get_blob_properties(container, blob, options).properties[:content_length]
+        end_range = [options[:end_range], blob_size].min
+        start_range = options[:start_range]
+        total_bytes = end_range - start_range
+
+        # if after calculating the real end_range it is below threshold, return
+        if total_bytes < parallel_threshold(options)
+          return get_blob(container, blob, options.merge({parallel_threshold: Float::INFINITY, start_range: start, end_range: fin}))
+        end
+
+        thread_count = client.storage_blob_parallel_threads
+        single_thread_chunk = (total_bytes.to_f / thread_count).ceil
+        ranges = (1..thread_count).to_a.map do |i|
+          start = options[:start_range] + ((i - 1) * single_thread_chunk)
+          fin = [start + single_thread_chunk - 1, options[:end_range]].min
+          [start, fin]
+        end
+
+        threads = []
+        ranges.each do |start, fin|
+          thread = Thread.new do
+            get_blob(container, blob, options.merge({parallel_threshold: Float::INFINITY, start_range: start, end_range: fin}))
+          end
+          thread.abort_on_exception = true
+          threads << thread
+        end
+
+        # each get_blob returns a [result, body]. Transpose into results, bodies 
+        results, bodies = threads.map(&:value).transpose
+        result = results.first
+        result.properties[:content_length] = total_bytes if result
+        return result, bodies.join
+      end
+
+    # Private: The number of bytes used to determine if a request should be parallelized
+    private
+      def parallel_threshold(options)
+        options[:parallel_threshold] || client.storage_blob_parallel_threshold || Float::INFINITY
+      end
   end
 end

--- a/blob/lib/azure/storage/blob/blob.rb
+++ b/blob/lib/azure/storage/blob/blob.rb
@@ -948,7 +948,7 @@ module Azure::Storage
 
         # if after calculating the real end_range it is below threshold, return
         if total_bytes < parallel_threshold(options)
-          return get_blob(container, blob, options.merge({parallel_threshold: Float::INFINITY, start_range: start, end_range: fin}))
+          return get_blob(container, blob, options.merge({parallel_threshold: Float::INFINITY, start_range: start_range, end_range: end_range}))
         end
 
         thread_count = client.storage_blob_parallel_threads

--- a/blob/lib/azure/storage/blob/default.rb
+++ b/blob/lib/azure/storage/blob/default.rb
@@ -86,7 +86,7 @@ module Azure::Storage::Blob
     DEFAULT_SINGLE_BLOB_PUT_THRESHOLD_IN_BYTES = 128 * 1024 * 1024
 
     # The default write block size, in bytes, used by blob streams.
-    DEFAULT_WRITE_BLOCK_SIZE_IN_BYTES = 4 * 1024 * 1024
+    DEFAULT_WRITE_BLOCK_SIZE_IN_BYTES = 5 * 1024 * 1024
 
     # The maximum size of a single block.
     MAX_BLOCK_SIZE = 100 * 1024 * 1024

--- a/common/lib/azure/storage/common/client.rb
+++ b/common/lib/azure/storage/common/client.rb
@@ -47,9 +47,12 @@ module Azure::Storage::Common
     # * +:storage_access_key+             - Base64 String. The access key of the storage account.
     # * +:storage_sas_token+              - String. The signed access signature for the storage account or one of its service.
     # * +:storage_blob_host+              - String. Specified Blob serivce endpoint or hostname
+    # * +:storage_blob_parallel_threshold+ - Integer. Complete requests concurrently if the range greater than or equal to this value.
+    # * +:storage_blob_parallel_threads+  - Integer. Number of threads for parallel operations. Should be less than http_pool_size.
     # * +:storage_table_host+             - String. Specified Table serivce endpoint or hostname
     # * +:storage_queue_host+             - String. Specified Queue serivce endpoint or hostname
     # * +:storage_dns_suffix+             - String. The suffix of a regional Storage Serivce, to
+    # * +:http_pool_size+                 - Integer. Persistent HTTP Client pool size.
     # * +:default_endpoints_protocol+     - String. http or https
     # * +:use_path_style_uri+             - String. Whether use path style URI for specified endpoints
     # * +:ca_file+                        - String. File path of the CA file if having issue with SSL
@@ -97,9 +100,12 @@ module Azure::Storage::Common
       # * +:storage_access_key+             - Base64 String. The access key of the storage account.
       # * +:storage_sas_token+              - String. The signed access signature for the storage account or one of its service.
       # * +:storage_blob_host+              - String. Specified Blob service endpoint or hostname
+      # * +:storage_blob_parallel_threshold+ - Integer. Complete requests concurrently if the range greater than or equal to this value.
+      # * +:storage_blob_parallel_threads+  - Integer. Number of threads for parallel operations. Should be less than http_pool_size.
       # * +:storage_table_host+             - String. Specified Table service endpoint or hostname
       # * +:storage_queue_host+             - String. Specified Queue service endpoint or hostname
       # * +:storage_dns_suffix+             - String. The suffix of a regional Storage Service, to
+      # * +:http_pool_size+                 - Integer. Persistent HTTP Client pool size.
       # * +:default_endpoints_protocol+     - String. http or https
       # * +:use_path_style_uri+             - String. Whether use path style URI for specified endpoints
       # * +:ca_file+                        - String. File path of the CA file if having issue with SSL

--- a/common/lib/azure/storage/common/configurable.rb
+++ b/common/lib/azure/storage/common/configurable.rb
@@ -39,6 +39,12 @@ module Azure::Storage::Common
     #     emulator). This should be the complete host, including http:// at the
     #     start. When using the emulator, make sure to include your account name at
     #     the end.
+    # @!attribute storage_blob_write_block_size
+    #  @return [Integer] Set the block size in bytes for blob writes
+    # @!attribute storage_blob_parallel_threshold
+    #  @return [Integer] Set the range threshold in bytes for blob operation parallelization.
+    # @!attribute storage_blob_parallel_threads
+    #  @return [Integer] Set the number of threads for blob operation parallelization.
     # @!attribute storage_table_host
     #   @return [String] Set the host for the Table service. Only set this if you want
     #     something custom (like, for example, to point this to a LocalStorage
@@ -55,7 +61,10 @@ module Azure::Storage::Common
     attr_accessor :storage_access_key,
                   :storage_account_name,
                   :storage_connection_string,
-                  :storage_sas_token
+                  :storage_sas_token,
+                  :storage_blob_write_block_size,
+                  :storage_blob_parallel_threshold,
+                  :storage_blob_parallel_threads
 
     attr_writer :storage_table_host,
                 :storage_blob_host,
@@ -79,6 +88,9 @@ module Azure::Storage::Common
           :storage_sas_token,
           :storage_table_host,
           :storage_blob_host,
+          :storage_blob_write_block_size,
+          :storage_blob_parallel_threshold,
+          :storage_blob_parallel_threads,
           :storage_queue_host,
           :storage_file_host,
           :signer

--- a/common/lib/azure/storage/common/core/http_client.rb
+++ b/common/lib/azure/storage/common/core/http_client.rb
@@ -72,7 +72,7 @@ module Azure::Storage::Common::Core
                         end || nil
         Faraday.new(uri, ssl: ssl_options, proxy: proxy_options) do |conn|
           conn.use FaradayMiddleware::FollowRedirects
-          conn.adapter :net_http_persistent, pool_size: 5 do |http|
+          conn.adapter :net_http_persistent, pool_size: (self.http_pool_size || 5) do |http|
             # yields Net::HTTP::Persistent
             http.idle_timeout = 100
           end

--- a/common/lib/azure/storage/common/default.rb
+++ b/common/lib/azure/storage/common/default.rb
@@ -115,6 +115,18 @@ module Azure::Storage::Common
         ENV["AZURE_STORAGE_BLOB_HOST"]
       end
 
+      def storage_blob_write_block_size
+        ENV["AZURE_STORAGE_BLOB_WRITE_BLOCK_SIZE"]&.to_i
+      end
+
+      def storage_blob_parallel_threads
+        ENV["AZURE_STORAGE_BLOB_PARALLEL_THREADS"]&.to_i
+      end
+
+      def storage_blob_parallel_threshold
+        ENV["AZURE_STORAGE_BLOB_PARALLEL_THRESHOLD"]&.to_i
+      end
+
       # Default storage queue host
       # @return [String]
       def storage_queue_host

--- a/test/unit/blob/blob_service_test.rb
+++ b/test/unit/blob/blob_service_test.rb
@@ -29,6 +29,16 @@ describe Azure::Storage::Blob::BlobService do
   subject {
     Azure::Storage::Blob::BlobService::create({ storage_account_name: "mockaccount", storage_access_key: "YWNjZXNzLWtleQ==" })
   }
+  let(:parallel_subject) {
+    Azure::Storage::Blob::BlobService::create(
+    {
+      storage_account_name: "mockaccount",
+      storage_access_key: "YWNjZXNzLWtleQ==",
+      storage_blob_parallel_threads: 2,
+      storage_blob_parallel_threshold: 4,
+      storage_blob_write_block_size: 4
+    })
+  }
   let(:serialization) { Azure::Storage::Blob::Serialization }
   let(:uri) { URI.parse "http://foo.com" }
   let(:query) { {} }
@@ -41,10 +51,17 @@ describe Azure::Storage::Blob::BlobService do
   let(:response_body) { mock() }
   let(:response) { mock() }
 
+  let(:parallel_response_headers) { {} }
+  let(:parallel_response_body) { "AB" }
+  let(:parallel_response) { mock() }
+
   before {
     response.stubs(:body).returns(response_body)
     response.stubs(:headers).returns(response_headers)
     subject.stubs(:call).returns(response)
+
+    parallel_response.stubs(:body).returns(parallel_response_body)
+    parallel_response.stubs(:headers).returns(parallel_response_headers)
   }
 
   describe "#get_user_delegation_key" do
@@ -2050,6 +2067,35 @@ describe Azure::Storage::Blob::BlobService do
           _(returned_blob).must_equal blob
 
           _(returned_blob_contents).must_equal response_body
+        end
+
+        it "fetches in parallel when parallel options are set" do
+          blob_length = 4
+          end_range = 4
+          parallel_subject.expects(:call).twice.returns(parallel_response)
+          parallel_subject.stubs(:get_blob_properties).returns(OpenStruct.new(properties: {content_length: blob_length}))
+          _, returned_blob_contents = parallel_subject.get_blob container_name, blob_name, {start_range: 0, end_range: end_range}
+
+          # The response is stubbed to return "AB" so fetching 4 bytes returns "AB" + "AB"
+          _(returned_blob_contents).must_equal (parallel_response_body + parallel_response_body)
+        end
+
+        it "fetches in parallel limited to blob size" do
+          blob_length = 4
+          end_range = 6
+          parallel_subject.expects(:call).twice.returns(parallel_response)
+          parallel_subject.stubs(:get_blob_properties).returns(OpenStruct.new(properties: {content_length: blob_length}))
+          _, returned_blob_contents = parallel_subject.get_blob container_name, blob_name, {start_range: 0, end_range: end_range}
+
+          # The response is stubbed to return "AB" so fetching 4 bytes returns "AB" + "AB"
+          _(returned_blob_contents).must_equal (parallel_response_body + parallel_response_body)
+        end
+
+        it "fetches in serial when below parallel threshold" do
+          parallel_subject.expects(:call).once.returns(parallel_response)
+          _, returned_blob_contents = parallel_subject.get_blob container_name, blob_name, {start_range: 0, end_range: 3}
+
+          _(returned_blob_contents).must_equal parallel_response_body
         end
 
         describe "when snapshot is provided" do

--- a/test/unit/config/client_services_test.rb
+++ b/test/unit/config/client_services_test.rb
@@ -85,5 +85,19 @@ describe Azure::Storage::Common::Client do
       _(subjectA.storage_queue_host).must_equal subjectB.storage_queue_host
       _(subjectA.storage_file_host).must_equal subjectB.storage_file_host
     end
+
+    it "storage with optional blob options works" do
+      subject = Azure::Storage::Common::Client.create(
+        storage_account_name: azure_storage_account,
+        storage_access_key: azure_storage_access_key,
+        storage_blob_parallel_threads: 3,
+        storage_blob_parallel_threshold: 6 * 1024 * 1024,
+        storage_blob_write_block_size: 9 * 1024 * 1024,
+        )
+
+      _(subject.storage_blob_parallel_threads).must_equal 3
+      _(subject.storage_blob_parallel_threshold).must_equal 6 * 1024 * 1024
+      _(subject.storage_blob_write_block_size).must_equal 9 * 1024 * 1024
+    end
   end
 end


### PR DESCRIPTION
This PR adds support for parallel uploads and parallel downloads (when using ranged gets). The change is generally useful but is specifically targeted to support Rails ActiveStorage performance improvements so you can, for example, setup a Rails storage configuration like:

```
# config/storage.yml
local:
  service: ParallelAzureStorage
  storage_account_name: <%= ENV["AZURE_STORAGE_ACCOUNT"] %>
  storage_access_key: <%= ENV["AZURE_STORAGE_ACCESS_KEY"] %>
  storage_blob_host: <%= ENV["AZURE_STORAGE_BLOB_HOST"] %>
  container:  <%= ENV["AZURE_STORAGE_BLOB_CONTAINER"] %>
  storage_blob_write_block_size: 10000000
  storage_blob_parallel_threshold: 75000000
  storage_blob_parallel_threads: 15
  http_pool_size: 20

# lib/active_storage/service/parallel_azure_storage_service.rb
module ActiveStorage # Once Rails natively supports setting a "stream_chunk_size", we can remove this
  class Service::ParallelAzureStorageService < Service::AzureStorageService
      def stream(key)
        blob = blob_for(key)
        stream_chunk_size = 300.megabytes
        offset = 0
        raise ActiveStorage::FileNotFoundError unless blob.present?
        while offset < blob.properties[:content_length]
          _, chunk = client.get_blob(container, key, start_range: offset, end_range: offset + stream_chunk_size - 1)
          yield chunk.force_encoding(Encoding::BINARY)
          offset += stream_chunk_size
        end
      end
  end
end
```

In that configuration, requests over 75MB would be fetched in parallel over 15 threads (each request getting 5MB).  Larger streamed requests would be fetched 300mb (`stream_chunk_size = 300.megabytes`) at a time in 15 parallel threads (each request getting 20MB).

Uploading and downloading larger blobs in parallel gives a significant performance boost (2x or 3x):

```
require "azure/storage/blob"
require "benchmark"

threehundredmeg = File.read("rand"); :DONE

parallel_client =  Azure::Storage::Blob::BlobService::create(
    {
      storage_account_name: "exampleaccount",
      storage_access_key: "AAexample_keyB==",
      storage_blob_parallel_threads: 5,
      storage_blob_parallel_threshold: 5 * 1024 * 1024
    })
super_parallel_client =  Azure::Storage::Blob::BlobService::create(
    {
      storage_account_name: "exampleaccount",
      storage_access_key: "AAexample_keyB==",
      storage_blob_parallel_threads: 15,
      storage_blob_parallel_threshold: 5 * 1024 * 1024,
      http_pool_size: 15
    })
single_client =  Azure::Storage::Blob::BlobService::create(
    {
      storage_account_name: "exampleaccount",
      storage_access_key: "AAexample_keyB==",
      storage_blob_parallel_threads: 1,
      storage_blob_parallel_threshold: 5 * 1024 * 1024
    })

Benchmark.measure { single_client.create_block_blob("data", "threehundred_single", threehundredmeg) }
=> #<Benchmark::Tms:0x00005624909c9630 @label="", @real=22.831228854000074, @cstime=0.0, @cutime=0.0, @stime=0.1568090000000001, @utime=3.0190269999999995, @total=3.1758359999999994>
Benchmark.measure { parllel_client.create_block_blob("data", "threehundred_parallel", threehundredmeg)
=> #<Benchmark::Tms:0x0000562490bc1a00 @label="", @real=9.799436117000027, @cstime=0.0, @cutime=0.0, @stime=0.27710099999999993, @utime=3.129546, @total=3.406647>

Benchmark.measure { single_client.get_blob("data", "threehundred_parallel", { start_range: 0, end_range: 300000000 }); :DONE }
=> #<Benchmark::Tms:0x0000562490c8bcd8 @label="", @real=13.33435237499998, @cstime=0.0, @cutime=0.0, @stime=0.4441289999999998, @utime=0.45342899999999986, @total=0.8975579999999996>
Benchmark.measure { parallel_client.get_blob("data", "threehundred_parallel", { start_range: 0, end_range: 300000000 }); :DONE }
=> #<Benchmark::Tms:0x0000562490c8bd00 @label="", @real=6.484543842999983, @cstime=0.0, @cutime=0.0, @stime=0.45743100000000014, @utime=0.4752680000000069, @total=0.932699000000007>
Benchmark.measure { super_parallel_client.get_blob("data", "threehundred_parallel", { start_range: 0, end_range: 300000000 }); :DONE }
=> #<Benchmark::Tms:0x00007fe3f83dbf60 @label="", @real=4.395406997000009, @cstime=0.0, @cutime=0.0, @stime=0.5267469999999999, @utime=0.5379800000000046, @total=1.0647270000000044>
```

I also updated DEFAULT_WRITE_BLOCK_SIZE_IN_BYTES to be 5MB to take advantage of [high throughput block blobs](https://docs.microsoft.com/en-us/azure/storage/blobs/storage-performance-checklist):

> If possible, use blob or block sizes greater than 4 MiB for standard storage accounts and greater than 256 KiB for premium storage accounts. Larger blob or block sizes automatically activate high-throughput block blobs. High-throughput block blobs provide high-performance ingest that is not affected by partition naming.

I don't think there's any real downside to defaulting to a value over 4MB, is there?